### PR TITLE
Add option to save .zip as .cbz

### DIFF
--- a/src/config/default.js
+++ b/src/config/default.js
@@ -256,7 +256,8 @@ export default Object.assign({}, {
     downloadMode: 1, // 1: legacy; 2: download manager
     dontCreateWorkFolder: 0,
     combinWRRuleAndIRRuleWhenDontCreateWorkFolder: 0,
-
+    globalZipFileExtension: '.zip',
+    
     /**
      * @since 1.0.0
      * @deprecated since version 6.0.0

--- a/src/options_page/components/NewSettings.vue
+++ b/src/options_page/components/NewSettings.vue
@@ -133,6 +133,12 @@ export default {
         globalZipMultipleImages: val
       });
     },
+    
+    zipFileExtension(val) {
+      browser.storage.local.set({
+        globalZipFileExtension: val
+      });
+    },
 
     dontCreateWorkFolder(val) {
       browser.storage.local.set({

--- a/src/options_page/components/options/GlobalTaskSettings.vue
+++ b/src/options_page/components/options/GlobalTaskSettings.vue
@@ -39,7 +39,21 @@
           ></v-select>
         </v-list-tile-action>
       </v-list-tile>
-
+        
+      <v-list-tile v-if="[1,2].indexOf(zipMultipleImages) > -1">
+        <v-list-tile-content>
+          <v-list-tile-title>
+            <v-list-tile-title>{{ tl('_zip_file_extension') }}</v-list-tile-title>
+          </v-list-tile-title>
+        </v-list-tile-content>
+        <v-list-tile-action>
+          <v-select :items="zipFileExtensionOptions"
+            v-model="zipFileExtension"
+            style="width:150px;"
+          ></v-select>
+        </v-list-tile-action>
+      </v-list-tile>    
+    
       <v-list-tile>
         <v-list-tile-content>
           <v-list-tile-title>{{ tl('_dont_create_work_folder') }}</v-list-tile-title>
@@ -78,7 +92,9 @@ export default {
       pageNumberLength: 0,
 
       zipMultipleImages: 1,
-
+      
+      zipFileExtension: '.zip',
+      
       dontCreateWorkFolder: 0,
 
       combinWRRuleAndIRRuleWhenDontCreateWorkFolder: 0
@@ -127,7 +143,17 @@ export default {
         value: 2
       }]
     },
-
+    
+    zipFileExtensionOptions() {
+      return [{
+        text: '.zip',
+        value: '.zip',
+      }, {
+        text: '.cbz',
+        value: '.cbz'
+      }]
+    },
+    
     dontCreateWorkFolderOptions() {
       return [{
         text: this.tl('_disable'),
@@ -160,6 +186,12 @@ export default {
         globalZipMultipleImages: val
       });
     },
+    
+    zipFileExtension(val) {
+      browser.storage.local.set({
+        globalZipFileExtension: val
+      });
+    },
 
     dontCreateWorkFolder(val) {
       browser.storage.local.set({
@@ -178,6 +210,7 @@ export default {
     this.pageNumberStartWithOne = this.browserItems.globalTaskPageNumberStartWithOne;
     this.pageNumberLength = this.browserItems.globalTaskPageNumberLength;
     this.zipMultipleImages = this.browserItems.globalZipMultipleImages;
+    this.zipFileExtension = this.browserItems.globalZipFileExtension;
     this.dontCreateWorkFolder = this.browserItems.dontCreateWorkFolder;
     this.combinWRRuleAndIRRuleWhenDontCreateWorkFolder = this.browserItems.combinWRRuleAndIRRuleWhenDontCreateWorkFolder;
   },

--- a/src/options_page/modules/DownloadTasks/MultiplePagesDownloadTask.js
+++ b/src/options_page/modules/DownloadTasks/MultiplePagesDownloadTask.js
@@ -199,7 +199,7 @@ class MultipleDownloadTask extends AbstractDownloadTask {
           action: 'download:saveFile',
           args: {
             url: URL.createObjectURL(blob),
-            filename: filename + '.zip'
+            filename: filename + GlobalSettings().globalZipFileExtension
           }
         });
 

--- a/src/options_page/modules/DownloadTasks/PixivComic/EpisodeDownloadTask.js
+++ b/src/options_page/modules/DownloadTasks/PixivComic/EpisodeDownloadTask.js
@@ -169,7 +169,7 @@ class EpisodeDownloadTask extends AbstractDownloadTask {
       this.zip.generateAsync({ type: 'blob' }).then(async blob => {
         this.lastDownloadId = await FileSystem.getDefault().saveFileInBackground({
           url: URL.createObjectURL(blob),
-          filename: pathjoin(GlobalSettings().downloadRelativeLocation, nameFormatter.format(this.options.renameRule, this.context.id)) + '.zip'
+          filename: pathjoin(GlobalSettings().downloadRelativeLocation, nameFormatter.format(this.options.renameRule, this.context.id)) +  GlobalSettings().globalZipFileExtension
         });
 
         this.changeState(this.COMPLETE_STATE);

--- a/src/statics/_locales/en/messages.json
+++ b/src/statics/_locales/en/messages.json
@@ -893,6 +893,9 @@
     "_zip_multiple_images": {
         "message": "Zip multiple images"
     },
+	"_zip_file_extension": {
+        "message": "Extension to use for ZIP filename"
+    },
     "_create_a_zip_file_while_downloading_multiple_images": {
         "message": "Create a zip file while downloading item which includes multiple images"
     },

--- a/src/statics/_locales/zh_CN/messages.json
+++ b/src/statics/_locales/zh_CN/messages.json
@@ -899,6 +899,9 @@
     "_zip_multiple_images": {
         "message": "多张图片打包成ZIP文件"
     },
+	"_zip_file_extension": {
+        "message": "用于ZIP文件名的扩展名"
+    },
     "_create_a_zip_file_while_downloading_multiple_images": {
         "message": "当下载的项目包含多张图片时打包成ZIP"
     },


### PR DESCRIPTION
Added an option to enable saving ZIP files as CBZ, so that they are compatible with comic readers!

Other options could easily be added in the future as well.