### PR TITLE
Fix Fanbox: download panel no longer appears (#334)

### DIFF
--- a/config/webpack.background.config.js
+++ b/config/webpack.background.config.js
@@ -66,6 +66,19 @@ module.exports = env => {
                * About manifest file, there are some differences between FireFox and browsers which based Chromium.
                * So we need do some extra works to make the target browser manifest file.
                */
+              if (platform === 'firefox') {
+                /**
+                 * Firefox implements the manifest v3 background as an event page,
+                 * it doesn't support `background.service_worker`. Convert it to
+                 * `background.scripts` so the extension can be loaded on Firefox.
+                 */
+                if (json.background && json.background.service_worker) {
+                  json.background = {
+                    scripts: [json.background.service_worker]
+                  };
+                }
+              }
+
               if (json.options_page && platform === 'firefox') {
                 console.log(`rename options_page to options_ui`);
 

--- a/src/background/services/FanboxService.js
+++ b/src/background/services/FanboxService.js
@@ -1,0 +1,62 @@
+import AbstractService from "./AbstractService";
+
+/**
+ * @class Fanbox service
+ *
+ * Fanbox serves its posts on `www.fanbox.cc` / `<creator>.fanbox.cc` but exposes
+ * its data through `api.fanbox.cc`. A credentialed request from the content
+ * script to that api is cross-origin, so it depends on the response carrying the
+ * right `Access-Control-Allow-Origin` / `Access-Control-Allow-Credentials`
+ * headers. Under manifest v2 those headers were rewritten by the (now removed)
+ * blocking webRequest handler; manifest v3 can't rewrite them for a credentialed
+ * request, which broke Fanbox (see issues #268 and #334).
+ *
+ * Fetching from the background service worker sidesteps the problem entirely:
+ * requests made here run with the extension's host permissions and aren't
+ * subject to page CORS, while `credentials: 'include'` still carries the Fanbox
+ * session cookie so supporter-only posts resolve.
+ */
+class FanboxService extends AbstractService {
+  /**
+   * @type {FanboxService}
+   */
+  static instance;
+
+  /**
+   * @returns {FanboxService}
+   */
+  static getService() {
+    if (!FanboxService.instance) {
+      FanboxService.instance = new FanboxService();
+    }
+
+    return FanboxService.instance;
+  }
+
+  /**
+   * Fetch a post's context data from the Fanbox api.
+   * @param {{ postId: string }} param0
+   * @returns {Promise<object>} The parsed api response, or an `{ error }` object
+   */
+  async postInfo({ postId }) {
+    try {
+      let response = await fetch(`https://api.fanbox.cc/post.info?postId=${postId}`, {
+        method: 'GET',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (!response.ok) {
+        return { error: `Fanbox api responded with status ${response.status}` };
+      }
+
+      return await response.json();
+    } catch (error) {
+      return { error: error.message || String(error) };
+    }
+  }
+}
+
+export default FanboxService;

--- a/src/background/services/index.js
+++ b/src/background/services/index.js
@@ -1,6 +1,7 @@
 import BadgeService from "./BadgeService";
 import DownloadFileService from './DownloadFileService';
 import DownloadService from "./DownloadService";
+import FanboxService from "./FanboxService";
 import HistoryService from "./HistoryService";
 import LogService from "./LogService";
 import SettingService from "./SettingService";
@@ -10,6 +11,7 @@ export default {
   BadgeService,
   DownloadFileService,
   DownloadService,
+  FanboxService,
   HistoryService,
   LogService,
   SettingService,

--- a/src/modules/Parser/Fanbox/PostParser.js
+++ b/src/modules/Parser/Fanbox/PostParser.js
@@ -173,7 +173,13 @@ class PostParser {
     }
 
     if (response && response.body) {
-      this.context = this.standardContext(response.body);
+      /**
+       * Fanbox now nests the post data under `body.post`; older responses put it
+       * directly on `body`. Support both so the post fields line up with what
+       * standardContext expects.
+       */
+      let post = response.body.post || response.body;
+      this.context = this.standardContext(post);
     } else {
       throw new RuntimeError(`Can't fetch fanbox post ${this.context.postId} context`);
     }

--- a/src/modules/Parser/Fanbox/PostParser.js
+++ b/src/modules/Parser/Fanbox/PostParser.js
@@ -1,6 +1,6 @@
 import { RuntimeError } from "@/errors";
 import DateFormatter from "@/modules/Util/DateFormatter";
-import Request from "@/modules/Net/Request";
+import browser from "@/modules/Extension/browser";
 
 /**
  * @class
@@ -27,9 +27,9 @@ class PostParser {
   context;
 
   /**
-   * @type {Request}
+   * @type {boolean} Whether the parse has been aborted
    */
-  request;
+  aborted = false;
 
   /**
    * @constructor
@@ -57,6 +57,7 @@ class PostParser {
   setUrl(url) {
     this.url = url;
     this.context = {};
+    this.aborted = false;
   }
 
   /**
@@ -89,15 +90,6 @@ class PostParser {
     }
 
     throw new RuntimeError(`Can't parse the post id and creator id out. url: ${this.url}`);
-  }
-
-  /**
-   * Build the url which will represet post context data
-   * @param {string} postId
-   * @returns {string}
-   */
-  buildContextUrl(postId) {
-    return `https://api.fanbox.cc/post.info?postId=${postId}`;
   }
 
   /**
@@ -153,48 +145,46 @@ class PostParser {
   }
 
   /**
-   * Parse post context data
+   * Parse post context data.
+   *
+   * The api request is delegated to the background service worker instead of
+   * being sent from here directly. This page runs on `*.fanbox.cc` while the api
+   * lives on `api.fanbox.cc`, so a direct credentialed request is cross-origin
+   * and fails CORS under manifest v3 (issues #268 and #334). The background
+   * worker isn't subject to page CORS and still sends the session cookie.
+   *
    * @returns {Promise.<any,Error>}
    */
-  parseContext() {
+  async parseContext() {
     this.parseUrl(this.url);
 
-    return new Promise((resolve, reject) => {
-      this.request = new Request(this.buildContextUrl(this.context.postId), {
-        method: 'GET',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-        }
-      });
-
-      this.request.addListener('onload', data => {
-        let textDecoder = new TextDecoder();
-        let json = JSON.parse(textDecoder.decode(data));
-
-        if (json && json.body) {
-          this.context = this.standardContext(json.body);
-          resolve();
-        } else {
-          reject(new RuntimeError(`Can't fetch fanbox post ${this.context.postId} context`));
-        }
-      });
-
-      this.request.addListener('onerror', error => {
-        reject(error);
-      });
-
-      this.request.send();
+    let response = await browser.runtime.sendMessage({
+      to: 'ws',
+      action: 'fanbox:postInfo',
+      args: { postId: this.context.postId },
     });
+
+    if (this.aborted) {
+      return;
+    }
+
+    if (response && response.error) {
+      throw new RuntimeError(`Can't fetch fanbox post ${this.context.postId} context: ${response.error}`);
+    }
+
+    if (response && response.body) {
+      this.context = this.standardContext(response.body);
+    } else {
+      throw new RuntimeError(`Can't fetch fanbox post ${this.context.postId} context`);
+    }
   }
 
   /**
-   * Abort request
+   * Abort parse. The background request itself can't be cancelled, so a late
+   * response is simply ignored.
    */
   abort() {
-    if (this.request) {
-      this.request.abort();
-    }
+    this.aborted = true;
   }
 }
 

--- a/src/statics/net_request_rules_1.json
+++ b/src/statics/net_request_rules_1.json
@@ -44,5 +44,29 @@
             "options_page/downloads.html"
         ]
     }
+  },
+  {
+    "id": 3,
+    "priority": 1,
+    "action" : {
+      "type": "modifyHeaders",
+      "requestHeaders": [
+        {
+            "header": "origin",
+            "operation": "set",
+            "value": "https://www.fanbox.cc"
+        },
+        {
+            "header": "referer",
+            "operation": "set",
+            "value": "https://www.fanbox.cc/"
+        }
+      ]
+    },
+    "condition": {
+        "urlFilter": "||api.fanbox.cc/",
+        "resourceType": ["xmlhttprequest", "other"],
+        "excludedInitiatorDomains": ["fanbox.cc"]
+    }
   }
 ]


### PR DESCRIPTION
Fixes #334 (also the recurring form of #268).

## Problem

On Fanbox posts the toolbar icon stays active (URL recognized) but the download panel never appears. The panel only mounts after `Application.urlchangeHandler` successfully calls `adapter.getResource()`, and for Fanbox that path was throwing.

## Root causes

1. **MV3 CORS regression.** `FanboxPostParser` fetched `https://api.fanbox.cc/post.info` directly from the content script. The page runs on `*.fanbox.cc` but the API is on `api.fanbox.cc`, so it's a cross-origin *credentialed* request. Under MV2 the blocking `webRequest` handler rewrote the response `Access-Control-Allow-Origin` / `-Allow-Credentials` headers; the MV3 migration dropped that, and `declarativeNetRequest` can't echo a dynamic origin for a credentialed request. So `getResource()` threw on CORS (matches the CORS/JSON errors reported in #268).

2. **Fanbox changed the `post.info` response shape.** The post fields (`user`, `type`, `body`, `coverImageUrl`, …) are now nested under `body.post` instead of sitting directly on `body`, so `standardContext()` hit `context.user` = `undefined`.

3. **Origin required by the API.** Once the request runs from the background it's CORS-free, but Fanbox rejected it with **HTTP 400** because the background sender's `Origin` is `moz-extension://…` / `chrome-extension://…`.

## Changes

- **Fetch `post.info` from the background service worker** (`FanboxService.postInfo`, action `fanbox:postInfo`). The background runs with host permissions, isn't subject to page CORS, and still sends the session cookie via `credentials: 'include'` (needed for supporter-only posts).
- **Unwrap `body.post`** in `FanboxPostParser`, falling back to `body` for older responses.
- **declarativeNetRequest rule** setting `Origin`/`Referer` to `https://www.fanbox.cc` on requests to `api.fanbox.cc`, scoped with `excludedInitiatorDomains: ["fanbox.cc"]` so it only touches the extension's own background request and never Fanbox's own SPA calls.
- **Firefox MV3 build:** transform the manifest during the Firefox build to emit `background.scripts` instead of `background.service_worker` (Firefox implements MV3 backgrounds as event pages; `background.service_worker` fails to load). All initialization already runs at the top level of `Bootstrap.js`, so nothing is lost.

## Testing

Built and loaded on **Firefox 153**. Verified the panel now appears on Fanbox posts (regular and supporter-only), the post parses, and downloads complete in **Download Manager** download mode.

## Not included / out of scope

Legacy download mode (`downloadMode: 1`, which zips inside the content script) has separate, pre-existing Firefox-MV3 content-script CSP problems (JSZip's `Function('return this')()` is CSP-blocked, and injected library globals aren't visible in Firefox's content-script sandbox). Those are intentionally left out of this PR; Download Manager mode is unaffected and works.

Pixiv Omnia while the button works, doesn't support Fanbox, it should be removed, unless at some point work is done to add Fanbox support to Pixiv Omnia.